### PR TITLE
Add Stylus Native Loader

### DIFF
--- a/topics/libraries.md
+++ b/topics/libraries.md
@@ -12,6 +12,7 @@
 - [Rupture](http://jescalan.github.io/rupture)
 - [SASS 2 Stylus](https://github.com/mojotech/sass2stylus)
 - [Stylus Loader](https://github.com/shama/stylus-loader)
+- [Stylus Native Loader](https://github.com/slightlyfaulty/stylus-native-loader)
 - [Stylus PHP](https://github.com/AustP/Stylus.php)
 - [Stylus Spriting](https://github.com/egermano/stylus-spriting)
 


### PR DESCRIPTION
[stylus-native-loader](https://github.com/slightlyfaulty/stylus-native-loader) is a light-weight alternative Stylus loader for Webpack. It solves [many issues](https://github.com/shama/stylus-loader/issues) with the original `stylus-loader` and boasts [faster build times](https://github.com/slightlyfaulty/stylus-native-loader#benchmarks).

`stylus-loader` has not been updated in over 2 years, so it's unlikely the plethora of outstanding issues will be fixed any time soon. A viable alternative is much needed for the die-hard Stylus community.